### PR TITLE
Fixed bug in ex-2-8

### DIFF
--- a/src/cljds/ch2/examples.clj
+++ b/src/cljds/ch2/examples.clj
@@ -73,7 +73,7 @@
   (let [may-1 (f/parse-local-date "2015-05-01")]
     (->> (load-data "dwell-times.tsv")
          (with-parsed-date)
-         (i/$where {:date {:$eq may-1}})
+         (filtered-times {:date {:$eq may-1}})
          (standard-error))))
 
 (defn ex-2-9 []


### PR DESCRIPTION
Standard error was attempting to calc mean of map entry of date and
dwell time rather than just dwell time.
